### PR TITLE
vpinsr(b|w|q): rename "ins_" to "ins", because there is no longer a conflict bet…

### DIFF
--- a/translator/src/instructions/vpinsrb.h
+++ b/translator/src/instructions/vpinsrb.h
@@ -33,10 +33,10 @@ void Xbyak::CodeGenerator::translateVPINSRB(xed_decoded_inst_t *p) {
 
   /* Col=Z103*/
   if (false || (a64.src2Type == A64_OP_REG && true)) {
-    xa_->ins_(xa::VReg16B(a64.dstIdx)[a64.uimm], xa::WReg(a64.src2Idx));
+    xa_->ins(xa::VReg16B(a64.dstIdx)[a64.uimm], xa::WReg(a64.src2Idx));
   }
   /* Col=AA103*/
   if (false || (a64.src2Type == A64_OP_MEM && true)) {
-    xa_->ins_(xa::VReg16B(a64.dstIdx)[a64.uimm], W_TMP_0);
+    xa_->ins(xa::VReg16B(a64.dstIdx)[a64.uimm], W_TMP_0);
   }
 }

--- a/translator/src/instructions/vpinsrq.h
+++ b/translator/src/instructions/vpinsrq.h
@@ -33,10 +33,10 @@ void Xbyak::CodeGenerator::translateVPINSRQ(xed_decoded_inst_t *p) {
 
   /* Col=Z103*/
   if (false || (a64.src2Type == A64_OP_REG && true)) {
-    xa_->ins_(xa::VReg2D(a64.dstIdx)[a64.uimm], xa::XReg(a64.src2Idx));
+    xa_->ins(xa::VReg2D(a64.dstIdx)[a64.uimm], xa::XReg(a64.src2Idx));
   }
   /* Col=AA103*/
   if (false || (a64.src2Type == A64_OP_MEM && true)) {
-    xa_->ins_(xa::VReg2D(a64.dstIdx)[a64.uimm], X_TMP_0);
+    xa_->ins(xa::VReg2D(a64.dstIdx)[a64.uimm], X_TMP_0);
   }
 }

--- a/translator/src/instructions/vpinsrw.h
+++ b/translator/src/instructions/vpinsrw.h
@@ -56,11 +56,11 @@ void Xbyak::CodeGenerator::translateVPINSRW(xed_decoded_inst_t *p) {
   }
   /* Col=AS119*/
   if (false || (a64.operands[2].opName == XED_OPERAND_REG2 && true)) {
-    xa_->ins_(xa::VReg8H(dstIdx)[uimm], xa::WReg(src2Idx));
+    xa_->ins(xa::VReg8H(dstIdx)[uimm], xa::WReg(src2Idx));
   }
   /* Col=AT119*/
   if (false || (a64.operands[2].opName == XED_OPERAND_MEM0 && true)) {
-    xa_->ins_(xa::VReg8H(dstIdx)[uimm], W_TMP_0);
+    xa_->ins(xa::VReg8H(dstIdx)[uimm], W_TMP_0);
   }
   /* Col=BO119*/
   if (false || (a64.operands[2].opName == XED_OPERAND_REG2 && true) ||


### PR DESCRIPTION
…ween Xbyak_aarch64 and oneDNN