### PR TITLE
ci: fix typo

### DIFF
--- a/.github/env/setenv-fcc
+++ b/.github/env/setenv-fcc
@@ -16,4 +16,4 @@
 #===============================================================================
 export CC="fcc -Nclang"
 export CXX="FCC -Nclang"
-export CFLAGS="-DXT_TEST -DDXT_AARCH64_STACK_REG"
+export CFLAGS="-DXT_TEST -DXT_AARCH64_STACK_REG"

--- a/.github/env/setenv-gcc
+++ b/.github/env/setenv-gcc
@@ -16,4 +16,4 @@
 #===============================================================================
 export CC=gcc
 export CXX=g++
-export CFLAGS="-DXT_TEST -DDXT_AARCH64_STACK_REG"
+export CFLAGS="-DXT_TEST -DXT_AARCH64_STACK_REG"

--- a/.github/env/setenv-gcc-qemu
+++ b/.github/env/setenv-gcc-qemu
@@ -16,5 +16,5 @@
 #===============================================================================
 export CC=/usr/bin/aarch64-linux-gnu-gcc
 export CXX=/usr/bin/aarch64-linux-gnu-g++
-export CFLAGS="-DXT_TEST -DDXT_AARCH64_STACK_REG"
+export CFLAGS="-DXT_TEST -DXT_AARCH64_STACK_REG"
 export QEMU_AARCH64=qemu-aarch64


### PR DESCRIPTION
CI passes even without XT_AARCH64_STACK_REG, but I added XT_AARCH64_STACK_REG as for the original intent of operation.