### PR TITLE
Fix typos: Liniux to Linux and std:cout to std::cout

### DIFF
--- a/build.md
+++ b/build.md
@@ -153,7 +153,7 @@ This command makes `mov000.cpp` without Xbyak_translator_aarch64,
 it means `mov000.cpp` is built as a pure x86_64 application written in Xbyak,
 and run it on x86_64 native environment (not QEMU). 
 It generates x86_64 machine code, executes the machine code generated, 
-and outputs the register values after execution to std:cout.
+and outputs the register values after execution to std::cout.
 The number of general purpose registers of x86_64 is 16, it is less than that of Armv8-A,
 so that output contains dummy value such as 
 `Output:G[16]:00000000_00000000` to `Output:G[31]:00000000_00000000`.

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ Please rewrite those code lines by Xbyak_aarch64 functions.
 
 |Hardware|CPU|OS|Compiler|
 |----|----|----|----|
-|Fujitsu PRIMEHPC FX700|A64FX|CentOS Liniux Version 8|g++ (GCC) 8.3.1|
+|Fujitsu PRIMEHPC FX700|A64FX|CentOS Linux Version 8|g++ (GCC) 8.3.1|
 
 You may try Xbyak_translator_aarch64 on QEMU (generic and open source machine emulator and virtualizer).
 We recommend using QEMU version 5.0.0 or higher, if you ports applications which use AVX2/AVX512 instructions by Xbyak.


### PR DESCRIPTION
Fixes typos in documentation files:

- readme.md: Corrected 'Liniux' to 'Linux' in the tested environment table
- build.md: Fixed 'std:cout' to 'std::cout' (proper C++ namespace syntax)